### PR TITLE
pattern_matching

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -48,6 +48,7 @@ jobs:
         python -m pip install pybedtools
         python -m pip install deeptools
         python -m pip install pybigwig
+        python -m pip install PyWavelets
         python setup.py sdist bdist_wheel
         python -m pip install .
 

--- a/consenrich/misc_util.py
+++ b/consenrich/misc_util.py
@@ -382,3 +382,18 @@ def dtr_wlen_degree(step: int, n: int=None,
         return 21,2
     return 25,2
 
+
+def get_max_match(intervals, values, pattern=None):
+    if pattern is None:
+        pattern = np.bartlett(len(values))
+
+    sig_xcorr = signal.correlate(values, pattern, mode='same')
+    max_idx = np.argmax(sig_xcorr)
+    # note the assumption of symmetry here
+    center = len(pattern) // 2
+    start = max(0, max_idx - center)
+    end = min(len(sig_xcorr), max_idx + center)
+    matched_region = intervals[start:end]
+
+    return matched_region, sig_xcorr[start:end]
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="consenrich",
-    version="0.1.7b1",
+    version="0.1.8b0",
     description="Genome-wide extraction of reproducible continuous-valued signals hidden in noisy multisample functional genomics data",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -28,6 +28,8 @@ setup(
         "data fusion",
         "state estimator",
         "filter",
+        "pattern matching",
+        "bioinformatics",
     ],
     packages=find_packages(),
     include_package_data=True,
@@ -40,6 +42,7 @@ setup(
         "pybedtools",
         "deeptools",
         "pyBigWig",
+        "PyWavelets",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Implements a matched filter and several experimental features for wavelet-based pattern matching in multisample-derived Consenrich outputs (signal tracks). These may be used for higher-resolution identification of substructure within broadly enriched regions. 

Runtime has been negligible in preliminary tests and should not dominate overall computational expense.

- `--match_wavelet <str>` triggers a per-chromosome matched filter against the wavelet specified in `<str>`. Consider Daubechies family (`db<k>`), (FIR) Meyer (`dmey`), and others supported by [PyWavelets](https://pywavelets.readthedocs.io/en/latest/)

This creates a BED file, `--match_output_file`, encompassing relative maxima in the filter response subject to constraints:

<img width="1529" alt="matched" src="https://github.com/user-attachments/assets/d55a9535-eab8-4e95-89bb-e651d2f467a7" />


Note that a single interval is included to represent the match.

-  The full filter response is included in the dictionary returned by `misc_utils/match_dwt()` but is *not* accessible through the command line interface that is already somewhat bloated. If needing greater control/access of the matching parameters and output, consider using the API.
