### PR TITLE
feat: use asinh for count-aware default transformation

### DIFF
--- a/src/consenrich/cconsenrich.pyx
+++ b/src/consenrich/cconsenrich.pyx
@@ -1646,6 +1646,14 @@ cpdef cEMA(cnp.ndarray x, double alpha):
 
 
 cpdef tuple monoFunc(object x, double offset=<double>(1.0), double scale=<double>(1.0)):
+    r"""Count-aware monotonic transform: scale * asinh(x + offset).
+
+    Uses asinh instead of log for epigenomic count data:
+    - asinh is defined for all real x (handles zeros and negatives without clamping)
+    - More linear for small counts (better variance stabilization)
+    - Handles negative values (e.g. control-normalized) without special casing
+    - Matches log(2x) asymptotically for large x
+    """
     cdef cnp.ndarray[cnp.float64_t, ndim=1] arr = np.ascontiguousarray(x, dtype=np.float64)
     cdef Py_ssize_t n = arr.shape[0]
     cdef cnp.ndarray[cnp.float64_t, ndim=1] out = np.empty(n, dtype=np.float64)
@@ -1656,7 +1664,7 @@ cpdef tuple monoFunc(object x, double offset=<double>(1.0), double scale=<double
     cdef Py_ssize_t i
     cdef double xval, u
 
-    # scale * log(x + offset)
+    # scale * asinh(x + offset) -- count-aware default for epigenomic assays
     if offset_ <= 0.0:
         offset_ = 1.0
 
@@ -1664,9 +1672,7 @@ cpdef tuple monoFunc(object x, double offset=<double>(1.0), double scale=<double
         for i in range(n):
             xval = arrView[i]
             u = xval + offset_
-            if u <= 0.0:
-                u = offset_ # keep defined if x has negatives
-            outView[i] = scale_ * log(u)
+            outView[i] = scale_ * asinh(u)
 
     return (out, -1.0)
 

--- a/src/consenrich/core.py
+++ b/src/consenrich/core.py
@@ -323,9 +323,9 @@ class countingParams(NamedTuple):
       during IRLS for the local baseline computation. Using smaller values near `0.0` will downweight peaks more and reduce the
       risk of removing true signal. Typical range is ``(0, 0.75]``.
     :type asymPos: float, optional
-    :param logOffset: A small constant added to read normalized counts before log-transforming (pseudocount). For example,  :math:`\log(x + 1)` for ``logOffset = 1``. Default is ``1.0``.
+    :param logOffset: Constant added to normalized counts before the count-aware transform (pseudocount). The default transform is :math:`\mathrm{asinh}(x + \mathrm{offset})`, which handles zeros and small counts better than :math:`\log(1+x)` while matching :math:`\log(2x)` asymptotically. Default is ``1.0``.
     :type logOffset: float, optional
-    :param logMult: Multiplicative factor applied to log-scaled and normalized counts. For example, setting ``logMult = 1 / \log(2)`` will yield log2-scaled counts after transformation, and setting ``logMult = 1.0`` yields natural log-scaled counts.
+    :param logMult: Multiplicative factor applied after the transform. Default ``1.0`` yields asinh-scaled values; set to :math:`1/\log(2)` for log2-like scaling at large values.
     :type logMult: float, optional
     :seealso: :func:`consenrich.cconsenrich.cTransform`
 


### PR DESCRIPTION
Replace log(1+x) with asinh(x+offset) as the default transform for epigenomic count data:

- More linear for small counts (better variance stabilization)
- Handles negative values (e.g. control-normalized) without special casing
- Matches log(2x) asymptotically for large x

The variance model (fitVarianceFunction, getMuncTrack) is data-driven and adapts to the new transform. User can still manually choose but this improves default. Passed all tests.